### PR TITLE
feat: ghcr.ioへのDockerイメージ自動プッシュワークフローを追加

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,80 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+      - docker
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+      - 'docker-entry.sh'
+      - '.github/workflows/docker-publish.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ibis-ssl/grsim
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,format=short
+            type=ref,event=pr
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## 概要

GitHub Actions による ghcr.io/ibis-ssl/grsim への Docker イメージ自動ビルド・プッシュワークフローを実装しました。

## 主な機能

- **自動ビルド・プッシュ**: master/docker ブランチへのプッシュで自動実行
- **バージョン管理**: タグ (v*.*.*) でバージョン管理されたイメージを生成
- **PR ビルド検証**: PR では build のみ実行（プッシュなし）
- **プラットフォーム**: linux/amd64 をサポート
- **高速化**: GitHub Actions キャッシュによる高速ビルド
- **セキュリティ**: SBOM と provenance attestation による透明性確保

## タグ生成ルール

| Git イベント | 生成されるタグ |
|-------------|---------------|
| master へのプッシュ | `latest`, `master`, `{SHA}` |
| docker へのプッシュ | `docker`, `{SHA}` |
| タグ v1.2.3 | `1.2.3`, `1.2`, `{SHA}` |
| PR #N | `pr-N` (ビルドのみ) |

## 動作確認

✅ docker ブランチでのワークフロー実行が成功しました
- 実行時間: 約4分39秒
- 生成イメージ: ghcr.io/ibis-ssl/grsim:docker

## テスト方法

```bash
docker pull ghcr.io/ibis-ssl/grsim:docker
docker run --rm ghcr.io/ibis-ssl/grsim:docker
```

## マージ後の影響

master にマージすると、以下のタグが自動生成されます:
- `ghcr.io/ibis-ssl/grsim:latest`
- `ghcr.io/ibis-ssl/grsim:master`
- `ghcr.io/ibis-ssl/grsim:{SHA}`

🤖 Generated with [Claude Code](https://claude.ai/code)