### PR TITLE
referee連動でbinary feedback送信IDを0..N-1へ正規化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ protobuf_generate_cpp(PROTO_CPP PROTO_H
     src/proto/grSim_Replacement.proto
     src/proto/grSim_Robotstatus.proto
     src/proto/ssl_gc_common.proto
+    src/proto/ssl_gc_referee_message.proto
     src/proto/ssl_simulation_config.proto
     src/proto/ssl_simulation_control.proto
     src/proto/ssl_simulation_error.proto
@@ -309,5 +310,4 @@ else()
     set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME_LOWER}_${CPACK_PACKAGE_VERSION}_${ARCH}")
 endif()
 include(CPack)
-
 

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -218,6 +218,10 @@ public:
   DEF_VALUE(bool, Bool, BinaryFeedbackEnabled)
   DEF_VALUE(std::string, String, BinaryFeedbackAddr)
   DEF_VALUE(int, Int, BinaryFeedbackPortBase)
+  DEF_VALUE(bool, Bool, BinaryFeedbackUseReferee)
+  DEF_VALUE(std::string, String, BinaryFeedbackRefereeAddr)
+  DEF_VALUE(int, Int, BinaryFeedbackRefereePort)
+  DEF_VALUE(std::string, String, BinaryFeedbackTeamName)
 
   void loadRobotSettings(QString team);
 public slots:  

--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -116,6 +116,9 @@ public:
 
     QElapsedTimer elapsedLastPackageBlue;
     QElapsedTimer elapsedLastPackageYellow;
+    QUdpSocket *refereeSocket{};
+    Team binaryFeedbackTeamSelection = UNKNOWN;
+    int binaryFeedbackWaitLogCounter = 0;
 
     bool updatedCursor;
     Robot* robots[MAX_ROBOT_COUNT*2]{};
@@ -126,6 +129,7 @@ public slots:
     void simControlSocketReady();
     void blueControlSocketReady();
     void yellowControlSocketReady();
+    void refereeSocketReady();
 signals:
     void fpsChanged(int newFPS);
 };

--- a/src/binary_feedback_sender.cpp
+++ b/src/binary_feedback_sender.cpp
@@ -127,9 +127,9 @@ void BinaryFeedbackSender::sendFeedback(int robotId, Robot* robot)
     buildPacket(buffer, robotId, robot);
 
     // 送信先アドレスとポート
-    // ポート = 50100 + robot_id
-    QHostAddress addr("127.0.0.1");
-    int port = 50100 + robotId;
+    // ポート = BinaryFeedbackPortBase + robot_id
+    QHostAddress addr(QString::fromStdString(cfg->BinaryFeedbackAddr()));
+    int port = cfg->BinaryFeedbackPortBase() + robotId;
 
     socket->writeDatagram(reinterpret_cast<const char*>(buffer), 128, addr, port);
 }

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -146,6 +146,10 @@ ConfigWidget::ConfigWidget() {
         ADD_VALUE(binary_feedback_vars,Bool,BinaryFeedbackEnabled,true,"Enable Binary Feedback")
         ADD_VALUE(binary_feedback_vars,String,BinaryFeedbackAddr,"127.0.0.1","Binary Feedback Address")
         ADD_VALUE(binary_feedback_vars,Int,BinaryFeedbackPortBase,50100,"Binary Feedback Port Base")
+        ADD_VALUE(binary_feedback_vars,Bool,BinaryFeedbackUseReferee,true,"Select Team from Referee")
+        ADD_VALUE(binary_feedback_vars,String,BinaryFeedbackRefereeAddr,"224.5.23.1","Referee Multicast Address")
+        ADD_VALUE(binary_feedback_vars,Int,BinaryFeedbackRefereePort,11003,"Referee Multicast Port")
+        ADD_VALUE(binary_feedback_vars,String,BinaryFeedbackTeamName,"ibis","Our Team Name")
     VarListPtr gauss_vars(new VarList("Gaussian noise"));
         comm_vars->addChild(gauss_vars);
         ADD_VALUE(gauss_vars,Bool,noise,false,"Noise")

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -276,6 +276,13 @@ MainWindow::MainWindow(QWidget *parent)
     QObject::connect(configwidget->v_SimControlListenPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectSimControlSocket()));
     QObject::connect(configwidget->v_BlueControlListenPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectBlueControlSocket()));
     QObject::connect(configwidget->v_YellowControlListenPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectYellowControlSocket()));
+    QObject::connect(configwidget->v_BinaryFeedbackEnabled.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackPortBase.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackUseReferee.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackRefereeAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackRefereePort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_BinaryFeedbackTeamName.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
     timer->start();
 
 

--- a/src/proto/ssl_gc_referee_message.proto
+++ b/src/proto/ssl_gc_referee_message.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+// Minimal subset of SSL Game Controller referee packet used by grSim.
+// This is intentionally partial; unknown fields are ignored by protobuf.
+message Referee {
+    message TeamInfo {
+        optional string name = 1;
+    }
+
+    optional TeamInfo yellow = 7;
+    optional TeamInfo blue = 8;
+}


### PR DESCRIPTION
## 概要
- Refereeマルチキャストを受信し、 「ibis」に一致したチームのみをbinary feedback送信対象にします
- 送信するを常にチーム内論理ID（0..N-1）に統一し、crane側でID正規化不要にしました
- Refereeで対象チームが未判定の間はbinary feedback送信を停止します
