### PR TITLE
GUI応答性の改善とWayland環境の互換性向上

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -50,6 +50,7 @@ public slots:
     void changeGravity();
     void changeTimer();
 
+    void scheduleRestartSimulator();
     void restartSimulator();
     void ballMenuTriggered(QAction* act);
     void toggleFullScreen(bool);
@@ -76,6 +77,7 @@ public slots:
 private:
     int getInterval();    
     QTimer *timer;
+    QTimer *restartDebounceTimer;
     GLWidget *glwidget;
     ConfigWidget *configwidget;
     ConfigDockWidget *dockconfig;

--- a/include/statuswidget.h
+++ b/include/statuswidget.h
@@ -65,7 +65,7 @@ public:
 
 public slots:
     void write(QString str, QColor color = QColor("black"));
-    void update();
+    void flushPendingMessages();
 
 private:
     CStatusPrinter *statusPrinter;


### PR DESCRIPTION
## Summary
設定変更時のGUIフリーズと遅延を解消し、Wayland環境でのXWayland自動切替を実装しました。

- 設定変更時のシミュレーター即座再起動を200msデバウンスに変更し、連続編集時の応答性を向上
- 設定編集中のGL更新をスキップすることで、入力時のUIフリーズを防止
- ステータスメッセージのバッチ処理（1フレーム最大64件）で描画負荷を軽減
- Wayland環境でQGLWidgetの問題を回避するため、XWaylandを自動選択する起動時ロジックを追加
- GLコンテキスト管理を改善（`makeCurrent()`/`doneCurrent()`追加）
- ステータスログの最大行数を2000に制限してメモリ使用量を最適化
